### PR TITLE
Fix concatMessageArray empty slice handling

### DIFF
--- a/schema/message.go
+++ b/schema/message.go
@@ -42,6 +42,10 @@ func init() {
 }
 
 func concatMessageArray(mas [][]*Message) ([]*Message, error) {
+	if len(mas) == 0 {
+		return nil, fmt.Errorf("empty message array")
+	}
+
 	arrayLen := len(mas[0])
 
 	ret := make([]*Message, arrayLen)

--- a/schema/message_test.go
+++ b/schema/message_test.go
@@ -742,3 +742,8 @@ func TestConcatToolCalls(t *testing.T) {
 		assert.EqualValues(t, expectedToolCall, tc)
 	})
 }
+
+func TestConcatMessageArrayEmpty(t *testing.T) {
+	_, err := concatMessageArray([][]*Message{})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- avoid panic when concatenating empty message arrays
- add unit test for empty slice

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_684842d6bdcc8321b9251d3b6d258303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent issues when processing empty message arrays.

- **Tests**
  - Added a test to verify correct error handling for empty message arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->